### PR TITLE
DEV-4439: Add status 5 to the check status function in Gataca QR component to avoid rescaning of a QR after it's been scanned

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gataca/qr",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Gataca component to display presentation requests in QR",
   "author": "Gataca <it@gataca.io>",
   "licenses": [

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -79,6 +79,10 @@ export namespace Components {
          */
         "clickInsideBoxLabel"?: string;
         /**
+          * _[Optional]_ String to show "click inside" label for QR already read
+         */
+        "clickInsideBoxReadedQrLabel"?: string;
+        /**
           * ***Mandatory*** Create session function to generate a new Session Using V1, it can provide just a session Id Using V2, it must provide also the authentication request. The session Id is the id of the presentation definition
          */
         "createSession"?: () => Promise<{
@@ -174,6 +178,10 @@ export namespace Components {
          */
         "qrSize"?: number;
         /**
+          * _[Optional]_ String to show when QR already read
+         */
+        "readedQrLabel"?: string;
+        /**
           * _[Optional]_ String to show "refresh QR" label
          */
         "refreshQrLabel"?: string;
@@ -258,6 +266,10 @@ export namespace Components {
          */
         "clickInsideBoxLabel"?: string;
         /**
+          * _[Optional]_ String to show "click inside" label for QR already read
+         */
+        "clickInsideBoxReadedQrLabel"?: string;
+        /**
           * _[Optional]_ String to show when credentials not validatedd
          */
         "credentialsNotValidatedLabel"?: string;
@@ -341,6 +353,10 @@ export namespace Components {
           * _[Optional]_ Size of QR Displayed
          */
         "qrSize"?: number;
+        /**
+          * _[Optional]_ String to show when QR already read
+         */
+        "readedQrLabel"?: string;
         /**
           * _[Optional]_ String to show "refresh QR" label
          */
@@ -734,6 +750,10 @@ declare namespace LocalJSX {
          */
         "clickInsideBoxLabel"?: string;
         /**
+          * _[Optional]_ String to show "click inside" label for QR already read
+         */
+        "clickInsideBoxReadedQrLabel"?: string;
+        /**
           * ***Mandatory*** Create session function to generate a new Session Using V1, it can provide just a session Id Using V2, it must provide also the authentication request. The session Id is the id of the presentation definition
          */
         "createSession"?: () => Promise<{
@@ -829,6 +849,10 @@ declare namespace LocalJSX {
          */
         "qrSize"?: number;
         /**
+          * _[Optional]_ String to show when QR already read
+         */
+        "readedQrLabel"?: string;
+        /**
           * _[Optional]_ String to show "refresh QR" label
          */
         "refreshQrLabel"?: string;
@@ -908,6 +932,10 @@ declare namespace LocalJSX {
           * _[Optional]_ String to show "click inside" label
          */
         "clickInsideBoxLabel"?: string;
+        /**
+          * _[Optional]_ String to show "click inside" label for QR already read
+         */
+        "clickInsideBoxReadedQrLabel"?: string;
         /**
           * _[Optional]_ String to show when credentials not validatedd
          */
@@ -992,6 +1020,10 @@ declare namespace LocalJSX {
           * _[Optional]_ Size of QR Displayed
          */
         "qrSize"?: number;
+        /**
+          * _[Optional]_ String to show when QR already read
+         */
+        "readedQrLabel"?: string;
         /**
           * _[Optional]_ String to show "refresh QR" label
          */

--- a/src/components/gataca-qr/components/retryButton/RetryButton.tsx
+++ b/src/components/gataca-qr/components/retryButton/RetryButton.tsx
@@ -12,9 +12,10 @@ type IRetryButtonProps = {
   waitingStartSessionLabel?: string;
   display: (x?: any) => void;
   renderRetryQR(value: string, useLogo?: boolean): any;
-  readedQrMessages?: string[];
-  readedQrLabel?: string;
-  clickInsideBoxReadedQrLabel?: string;
+  readedQrMessages?: {
+    title?: string;
+    description?: string;
+  };
 };
 
 export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
@@ -28,8 +29,6 @@ export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
     display,
     renderRetryQR,
     readedQrMessages,
-    readedQrLabel,
-    clickInsideBoxReadedQrLabel,
   } = props;
 
   return (
@@ -43,14 +42,14 @@ export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
       <div id="notify" onClick={() => display()}>
         <img src={refreshIcon} height={24} width={24} />
         {readedQrMessages ? (
-          <p class="notify-text">{readedQrLabel} </p>
+          <p class="notify-text">{readedQrMessages?.title} </p>
         ) : (
           <p class="notify-text">{clickInsideBoxLabel} </p>
         )}
         {errorMessage ? (
           <p class="notify-text bold">{refreshQrLabel}</p>
         ) : readedQrMessages ? (
-          <p class="notify-text bold">{clickInsideBoxReadedQrLabel}</p>
+          <p class="notify-text bold">{readedQrMessages?.description}</p>
         ) : (
           <p class="notify-text bold">{scanQrLabel}</p>
         )}

--- a/src/components/gataca-qr/components/retryButton/RetryButton.tsx
+++ b/src/components/gataca-qr/components/retryButton/RetryButton.tsx
@@ -12,6 +12,9 @@ type IRetryButtonProps = {
   waitingStartSessionLabel?: string;
   display: (x?: any) => void;
   renderRetryQR(value: string, useLogo?: boolean): any;
+  readedQrMessages?: string[];
+  readedQrLabel?: string;
+  clickInsideBoxReadedQrLabel?: string;
 };
 
 export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
@@ -24,6 +27,9 @@ export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
     waitingStartSessionLabel,
     display,
     renderRetryQR,
+    readedQrMessages,
+    readedQrLabel,
+    clickInsideBoxReadedQrLabel,
   } = props;
 
   return (
@@ -36,9 +42,15 @@ export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
     >
       <div id="notify" onClick={() => display()}>
         <img src={refreshIcon} height={24} width={24} />
-        <p class="notify-text">{clickInsideBoxLabel} </p>
+        {readedQrMessages ? (
+          <p class="notify-text">{readedQrLabel} </p>
+        ) : (
+          <p class="notify-text">{clickInsideBoxLabel} </p>
+        )}
         {errorMessage ? (
           <p class="notify-text bold">{refreshQrLabel}</p>
+        ) : readedQrMessages ? (
+          <p class="notify-text bold">{clickInsideBoxReadedQrLabel}</p>
         ) : (
           <p class="notify-text bold">{scanQrLabel}</p>
         )}

--- a/src/components/gataca-qr/gataca-qr.tsx
+++ b/src/components/gataca-qr/gataca-qr.tsx
@@ -245,6 +245,18 @@ export class GatacaQR {
 
   /**
    * _[Optional]_
+   * String to show when QR already read
+   */
+  @Prop() readedQrLabel?: string = "QR Code already scanned.";
+
+  /**
+   * _[Optional]_
+   * String to show "click inside" label for QR already read
+   */
+  @Prop() clickInsideBoxReadedQrLabel?: string = "Click the box to refresh.";
+
+  /**
+   * _[Optional]_
    * Boolean to show or not show the QR Modal description
    */
   @Prop() hideQrModalDescription?: boolean = false;
@@ -436,6 +448,11 @@ export class GatacaQR {
         return this.renderRetryButton(this.credentialsNotValidatedLabel);
       case RESULT_STATUS.SUCCESS:
         return this.renderSuccess();
+      case RESULT_STATUS.READED:
+        return this.renderRetryButton(null, [
+          this?.readedQrLabel,
+          this?.clickInsideBoxReadedQrLabel,
+        ]);
     }
   }
 
@@ -448,7 +465,7 @@ export class GatacaQR {
     );
   }
 
-  renderRetryButton(errorMessage?: string) {
+  renderRetryButton(errorMessage?: string, readedQrMessages?: string[]) {
     return (
       <RetryButton
         errorMessage={errorMessage}
@@ -459,6 +476,9 @@ export class GatacaQR {
         waitingStartSessionLabel={this?.waitingStartSessionLabel}
         display={this.display.bind(this)}
         renderRetryQR={this.renderRetryQR.bind(this)}
+        readedQrMessages={readedQrMessages}
+        readedQrLabel={this?.readedQrLabel}
+        clickInsideBoxReadedQrLabel={this?.clickInsideBoxReadedQrLabel}
       />
     );
   }

--- a/src/components/gataca-qr/gataca-qr.tsx
+++ b/src/components/gataca-qr/gataca-qr.tsx
@@ -449,10 +449,10 @@ export class GatacaQR {
       case RESULT_STATUS.SUCCESS:
         return this.renderSuccess();
       case RESULT_STATUS.READED:
-        return this.renderRetryButton(null, [
-          this?.readedQrLabel,
-          this?.clickInsideBoxReadedQrLabel,
-        ]);
+        return this.renderRetryButton(null, {
+          title: this?.readedQrLabel,
+          description: this?.clickInsideBoxReadedQrLabel,
+        });
     }
   }
 
@@ -465,7 +465,10 @@ export class GatacaQR {
     );
   }
 
-  renderRetryButton(errorMessage?: string, readedQrMessages?: string[]) {
+  renderRetryButton(
+    errorMessage?: string,
+    readedQrMessages?: { title; description }
+  ) {
     return (
       <RetryButton
         errorMessage={errorMessage}
@@ -477,8 +480,6 @@ export class GatacaQR {
         display={this.display.bind(this)}
         renderRetryQR={this.renderRetryQR.bind(this)}
         readedQrMessages={readedQrMessages}
-        readedQrLabel={this?.readedQrLabel}
-        clickInsideBoxReadedQrLabel={this?.clickInsideBoxReadedQrLabel}
       />
     );
   }

--- a/src/components/gataca-qrws/components/retryButton/RetryButton.tsx
+++ b/src/components/gataca-qrws/components/retryButton/RetryButton.tsx
@@ -12,9 +12,10 @@ type IRetryButtonProps = {
   waitingStartSessionLabel?: string;
   display: (x?: any) => void;
   renderRetryQR(value: string, useLogo?: boolean): any;
-  readedQrMessages?: string[];
-  readedQrLabel?: string;
-  clickInsideBoxReadedQrLabel?: string;
+  readedQrMessages?: {
+    title?: string;
+    description?: string;
+  };
 };
 
 export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
@@ -28,8 +29,6 @@ export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
     display,
     renderRetryQR,
     readedQrMessages,
-    readedQrLabel,
-    clickInsideBoxReadedQrLabel,
   } = props;
 
   return (
@@ -43,14 +42,14 @@ export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
       <div id="notify" onClick={() => display()}>
         <img src={refreshIcon} height={24} width={24} />
         {readedQrMessages ? (
-          <p class="notify-text">{readedQrLabel} </p>
+          <p class="notify-text">{readedQrMessages?.title} </p>
         ) : (
           <p class="notify-text">{clickInsideBoxLabel} </p>
         )}
         {errorMessage ? (
           <p class="notify-text bold">{refreshQrLabel}</p>
         ) : readedQrMessages ? (
-          <p class="notify-text bold">{clickInsideBoxReadedQrLabel}</p>
+          <p class="notify-text bold">{readedQrMessages?.description}</p>
         ) : (
           <p class="notify-text bold">{scanQrLabel}</p>
         )}

--- a/src/components/gataca-qrws/components/retryButton/RetryButton.tsx
+++ b/src/components/gataca-qrws/components/retryButton/RetryButton.tsx
@@ -12,6 +12,9 @@ type IRetryButtonProps = {
   waitingStartSessionLabel?: string;
   display: (x?: any) => void;
   renderRetryQR(value: string, useLogo?: boolean): any;
+  readedQrMessages?: string[];
+  readedQrLabel?: string;
+  clickInsideBoxReadedQrLabel?: string;
 };
 
 export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
@@ -24,6 +27,9 @@ export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
     waitingStartSessionLabel,
     display,
     renderRetryQR,
+    readedQrMessages,
+    readedQrLabel,
+    clickInsideBoxReadedQrLabel,
   } = props;
 
   return (
@@ -36,9 +42,15 @@ export const RetryButton: React.FC<IRetryButtonProps> = (props) => {
     >
       <div id="notify" onClick={() => display()}>
         <img src={refreshIcon} height={24} width={24} />
-        <p class="notify-text">{clickInsideBoxLabel} </p>
+        {readedQrMessages ? (
+          <p class="notify-text">{readedQrLabel} </p>
+        ) : (
+          <p class="notify-text">{clickInsideBoxLabel} </p>
+        )}
         {errorMessage ? (
           <p class="notify-text bold">{refreshQrLabel}</p>
+        ) : readedQrMessages ? (
+          <p class="notify-text bold">{clickInsideBoxReadedQrLabel}</p>
         ) : (
           <p class="notify-text bold">{scanQrLabel}</p>
         )}

--- a/src/components/gataca-qrws/gataca-qrws.tsx
+++ b/src/components/gataca-qrws/gataca-qrws.tsx
@@ -452,10 +452,10 @@ export class GatacaQRWS {
       case RESULT_STATUS.SUCCESS:
         return this.renderSuccess();
       case RESULT_STATUS.READED:
-        return this.renderRetryButton(null, [
-          this?.readedQrLabel,
-          this?.clickInsideBoxReadedQrLabel,
-        ]);
+        return this.renderRetryButton(null, {
+          title: this?.readedQrLabel,
+          description: this?.clickInsideBoxReadedQrLabel,
+        });
     }
   }
 
@@ -468,7 +468,10 @@ export class GatacaQRWS {
     );
   }
 
-  renderRetryButton(errorMessage?: string, readedQrMessages?: string[]) {
+  renderRetryButton(
+    errorMessage?: string,
+    readedQrMessages?: { title; description }
+  ) {
     return (
       <RetryButton
         errorMessage={errorMessage}
@@ -480,8 +483,6 @@ export class GatacaQRWS {
         display={this.display.bind(this)}
         renderRetryQR={this.renderRetryQR.bind(this)}
         readedQrMessages={readedQrMessages}
-        readedQrLabel={this?.readedQrLabel}
-        clickInsideBoxReadedQrLabel={this?.clickInsideBoxReadedQrLabel}
       />
     );
   }

--- a/src/components/gataca-qrws/gataca-qrws.tsx
+++ b/src/components/gataca-qrws/gataca-qrws.tsx
@@ -253,6 +253,18 @@ export class GatacaQRWS {
 
   /**
    * _[Optional]_
+   * String to show when QR already read
+   */
+  @Prop() readedQrLabel?: string = "QR Code already scanned.";
+
+  /**
+   * _[Optional]_
+   * String to show "click inside" label for QR already read
+   */
+  @Prop() clickInsideBoxReadedQrLabel?: string = "Click the box to refresh.";
+
+  /**
+   * _[Optional]_
    * Boolean to show or not show the QR Modal description
    */
   @Prop() hideQrModalDescription?: boolean = false;
@@ -439,6 +451,11 @@ export class GatacaQRWS {
         return this.renderRetryButton(this.credentialsNotValidatedLabel);
       case RESULT_STATUS.SUCCESS:
         return this.renderSuccess();
+      case RESULT_STATUS.READED:
+        return this.renderRetryButton(null, [
+          this?.readedQrLabel,
+          this?.clickInsideBoxReadedQrLabel,
+        ]);
     }
   }
 
@@ -451,7 +468,7 @@ export class GatacaQRWS {
     );
   }
 
-  renderRetryButton(errorMessage?: string) {
+  renderRetryButton(errorMessage?: string, readedQrMessages?: string[]) {
     return (
       <RetryButton
         errorMessage={errorMessage}
@@ -462,6 +479,9 @@ export class GatacaQRWS {
         waitingStartSessionLabel={this?.waitingStartSessionLabel}
         display={this.display.bind(this)}
         renderRetryQR={this.renderRetryQR.bind(this)}
+        readedQrMessages={readedQrMessages}
+        readedQrLabel={this?.readedQrLabel}
+        clickInsideBoxReadedQrLabel={this?.clickInsideBoxReadedQrLabel}
       />
     );
   }

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -25,6 +25,7 @@ export enum RESULT_STATUS {
   SUCCESS = 1,
   FAILED = 2,
   EXPIRED = 3,
+  READED = 5,
 }
 
 export type WSResponse = {

--- a/stats.json
+++ b/stats.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2024-12-16T13:45:28",
+  "timestamp": "2024-12-18T08:14:29",
   "compiler": {
     "name": "node",
     "version": "18.17.0"
@@ -138,7 +138,7 @@
           "utils-1b406699.js",
           "gat-icon-alert-13a1894e.js"
         ],
-        "originalByteSize": 16350
+        "originalByteSize": 16286
       },
       {
         "key": "gataca-qrws.entry",
@@ -153,7 +153,7 @@
           "utils-1b406699.js",
           "gat-icon-alert-13a1894e.js"
         ],
-        "originalByteSize": 16445
+        "originalByteSize": 16381
       },
       {
         "key": "gataca-qrdisplay.entry",
@@ -6234,8 +6234,6 @@
             "display",
             "renderRetryQR",
             "readedQrMessages",
-            "readedQrLabel",
-            "clickInsideBoxReadedQrLabel",
             "value",
             "useLogo",
             "size",
@@ -7247,8 +7245,6 @@
             "display",
             "renderRetryQR",
             "readedQrMessages",
-            "readedQrLabel",
-            "clickInsideBoxReadedQrLabel",
             "value",
             "useLogo",
             "size",
@@ -7546,7 +7542,6 @@
     ]
   },
   "sourceGraph": {
-    "./src/components/gataca-autoqr/gataca-autoqr.e2e.ts": [],
     "./src/components/gataca-autoqr/gataca-autoqr.tsx": [],
     "./src/components/gataca-qr/components/qr/QR.tsx": [],
     "./src/components/gataca-qr/components/retryButton/RetryButton.tsx": [
@@ -7556,7 +7551,6 @@
     "./src/components/gataca-qr/components/success/Success.tsx": [
       "./src/assets/icons/gat-icon-check.svg"
     ],
-    "./src/components/gataca-qr/gataca-qr.e2e.ts": [],
     "./src/components/gataca-qr/gataca-qr.tsx": [
       "./src/assets/images/logo_gataca.svg",
       "./src/components/gataca-qr/components/qr/QR",
@@ -7565,7 +7559,6 @@
       "./src/components/gataca-qrdisplay/gataca-qrdisplay",
       "./src/utils/utils"
     ],
-    "./src/components/gataca-qrdisplay/gataca-qrdisplay.e2e.ts": [],
     "./src/components/gataca-qrdisplay/gataca-qrdisplay.tsx": [
       "./src/assets/images/logo_gataca.svg"
     ],
@@ -7577,7 +7570,6 @@
     "./src/components/gataca-qrws/components/success/Success.tsx": [
       "./src/assets/icons/gat-icon-check.svg"
     ],
-    "./src/components/gataca-qrws/gataca-qrws.e2e.ts": [],
     "./src/components/gataca-qrws/gataca-qrws.tsx": [
       "./src/assets/images/logo_gataca.svg",
       "./src/components/gataca-qrdisplay/gataca-qrdisplay",
@@ -7586,11 +7578,9 @@
       "./src/components/gataca-qrws/components/success/Success",
       "./src/utils/utils"
     ],
-    "./src/components/gataca-ssibutton/gataca-ssibutton.e2e.ts": [],
     "./src/components/gataca-ssibutton/gataca-ssibutton.tsx": [
       "./src/components/gataca-qrdisplay/gataca-qrdisplay"
     ],
-    "./src/components/gataca-ssibuttonws/gataca-ssibuttonws.e2e.ts": [],
     "./src/components/gataca-ssibuttonws/gataca-ssibuttonws.tsx": [],
     "./src/index.ts": [],
     "./src/utils/index.ts": [],

--- a/stats.json
+++ b/stats.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2024-04-04T17:07:21",
+  "timestamp": "2024-12-16T13:45:28",
   "compiler": {
     "name": "node",
     "version": "18.17.0"
@@ -43,7 +43,7 @@
           "./dist/gatacaqr/index-34dab51c.js",
           "./dist/gatacaqr/index.esm.js",
           "./dist/gatacaqr/shadow-css-98135883.js",
-          "./dist/gatacaqr/utils-05ba6c9f.js",
+          "./dist/gatacaqr/utils-1b406699.js",
           "./www/build/app-globals-0f993ce5.js",
           "./www/build/css-shim-b7d3d95f.js",
           "./www/build/dom-64053c71.js",
@@ -59,7 +59,7 @@
           "./www/build/index-34dab51c.js",
           "./www/build/index.esm.js",
           "./www/build/shadow-css-98135883.js",
-          "./www/build/utils-05ba6c9f.js"
+          "./www/build/utils-1b406699.js"
         ]
       },
       {
@@ -135,10 +135,10 @@
         "imports": [
           "index-34dab51c.js",
           "gataca-qrdisplay-0146c456.js",
-          "utils-05ba6c9f.js",
+          "utils-1b406699.js",
           "gat-icon-alert-13a1894e.js"
         ],
-        "originalByteSize": 15498
+        "originalByteSize": 16350
       },
       {
         "key": "gataca-qrws.entry",
@@ -150,10 +150,10 @@
         "imports": [
           "index-34dab51c.js",
           "gataca-qrdisplay-0146c456.js",
-          "utils-05ba6c9f.js",
+          "utils-1b406699.js",
           "gat-icon-alert-13a1894e.js"
         ],
-        "originalByteSize": 15593
+        "originalByteSize": 16445
       },
       {
         "key": "gataca-qrdisplay.entry",
@@ -1220,6 +1220,46 @@
           "internal": false
         },
         {
+          "name": "readedQrLabel",
+          "type": "string",
+          "attribute": "readed-qr-label",
+          "reflect": false,
+          "mutable": false,
+          "required": false,
+          "optional": true,
+          "defaultValue": "\"QR Code already scanned.\"",
+          "complexType": {
+            "original": "string",
+            "resolved": "string",
+            "references": {}
+          },
+          "docs": {
+            "tags": [],
+            "text": "_[Optional]_\nString to show when QR already read"
+          },
+          "internal": false
+        },
+        {
+          "name": "clickInsideBoxReadedQrLabel",
+          "type": "string",
+          "attribute": "click-inside-box-readed-qr-label",
+          "reflect": false,
+          "mutable": false,
+          "required": false,
+          "optional": true,
+          "defaultValue": "\"Click the box to refresh.\"",
+          "complexType": {
+            "original": "string",
+            "resolved": "string",
+            "references": {}
+          },
+          "docs": {
+            "tags": [],
+            "text": "_[Optional]_\nString to show \"click inside\" label for QR already read"
+          },
+          "internal": false
+        },
+        {
           "name": "hideQrModalDescription",
           "type": "boolean",
           "attribute": "hide-qr-modal-description",
@@ -2275,6 +2315,46 @@
           "docs": {
             "tags": [],
             "text": "_[Optional]_\nString to show \"waiting start session\" label"
+          },
+          "internal": false
+        },
+        {
+          "name": "readedQrLabel",
+          "type": "string",
+          "attribute": "readed-qr-label",
+          "reflect": false,
+          "mutable": false,
+          "required": false,
+          "optional": true,
+          "defaultValue": "\"QR Code already scanned.\"",
+          "complexType": {
+            "original": "string",
+            "resolved": "string",
+            "references": {}
+          },
+          "docs": {
+            "tags": [],
+            "text": "_[Optional]_\nString to show when QR already read"
+          },
+          "internal": false
+        },
+        {
+          "name": "clickInsideBoxReadedQrLabel",
+          "type": "string",
+          "attribute": "click-inside-box-readed-qr-label",
+          "reflect": false,
+          "mutable": false,
+          "required": false,
+          "optional": true,
+          "defaultValue": "\"Click the box to refresh.\"",
+          "complexType": {
+            "original": "string",
+            "resolved": "string",
+            "references": {}
+          },
+          "docs": {
+            "tags": [],
+            "text": "_[Optional]_\nString to show \"click inside\" label for QR already read"
           },
           "internal": false
         },
@@ -5836,6 +5916,46 @@
               "internal": false
             },
             {
+              "name": "readedQrLabel",
+              "type": "string",
+              "attribute": "readed-qr-label",
+              "reflect": false,
+              "mutable": false,
+              "required": false,
+              "optional": true,
+              "defaultValue": "\"QR Code already scanned.\"",
+              "complexType": {
+                "original": "string",
+                "resolved": "string",
+                "references": {}
+              },
+              "docs": {
+                "tags": [],
+                "text": "_[Optional]_\nString to show when QR already read"
+              },
+              "internal": false
+            },
+            {
+              "name": "clickInsideBoxReadedQrLabel",
+              "type": "string",
+              "attribute": "click-inside-box-readed-qr-label",
+              "reflect": false,
+              "mutable": false,
+              "required": false,
+              "optional": true,
+              "defaultValue": "\"Click the box to refresh.\"",
+              "complexType": {
+                "original": "string",
+                "resolved": "string",
+                "references": {}
+              },
+              "docs": {
+                "tags": [],
+                "text": "_[Optional]_\nString to show \"click inside\" label for QR already read"
+              },
+              "internal": false
+            },
+            {
               "name": "hideQrModalDescription",
               "type": "boolean",
               "attribute": "hide-qr-modal-description",
@@ -6113,6 +6233,9 @@
             "waitingStartSessionLabel",
             "display",
             "renderRetryQR",
+            "readedQrMessages",
+            "readedQrLabel",
+            "clickInsideBoxReadedQrLabel",
             "value",
             "useLogo",
             "size",
@@ -6836,6 +6959,46 @@
               "internal": false
             },
             {
+              "name": "readedQrLabel",
+              "type": "string",
+              "attribute": "readed-qr-label",
+              "reflect": false,
+              "mutable": false,
+              "required": false,
+              "optional": true,
+              "defaultValue": "\"QR Code already scanned.\"",
+              "complexType": {
+                "original": "string",
+                "resolved": "string",
+                "references": {}
+              },
+              "docs": {
+                "tags": [],
+                "text": "_[Optional]_\nString to show when QR already read"
+              },
+              "internal": false
+            },
+            {
+              "name": "clickInsideBoxReadedQrLabel",
+              "type": "string",
+              "attribute": "click-inside-box-readed-qr-label",
+              "reflect": false,
+              "mutable": false,
+              "required": false,
+              "optional": true,
+              "defaultValue": "\"Click the box to refresh.\"",
+              "complexType": {
+                "original": "string",
+                "resolved": "string",
+                "references": {}
+              },
+              "docs": {
+                "tags": [],
+                "text": "_[Optional]_\nString to show \"click inside\" label for QR already read"
+              },
+              "internal": false
+            },
+            {
               "name": "hideQrModalDescription",
               "type": "boolean",
               "attribute": "hide-qr-modal-description",
@@ -7083,6 +7246,9 @@
             "waitingStartSessionLabel",
             "display",
             "renderRetryQR",
+            "readedQrMessages",
+            "readedQrLabel",
+            "clickInsideBoxReadedQrLabel",
             "value",
             "useLogo",
             "size",
@@ -7358,7 +7524,7 @@
     "sc-gataca-qr": [
       "index-34dab51c.js",
       "gataca-qrdisplay-0146c456.js",
-      "utils-05ba6c9f.js",
+      "utils-1b406699.js",
       "gat-icon-alert-13a1894e.js"
     ],
     "sc-gataca-qrdisplay": [
@@ -7368,7 +7534,7 @@
     "sc-gataca-qrws": [
       "index-34dab51c.js",
       "gataca-qrdisplay-0146c456.js",
-      "utils-05ba6c9f.js",
+      "utils-1b406699.js",
       "gat-icon-alert-13a1894e.js"
     ],
     "sc-gataca-ssibutton": [


### PR DESCRIPTION
JIRA:

[Add status 5 to the check status function in Gataca QR component to avoid rescaning of a QR after it's been scanned](https://gataca.atlassian.net/browse/DEV-4439)

DONE:
 - add status 5 (Readed) to check status function
 - RetryButton: add messages related to status 5. Copies & look n feel provided by Tefy.

RESULT:

<img width="303" alt="Screenshot 2024-12-16 at 14 37 17" src="https://github.com/user-attachments/assets/0edd202a-a0be-41d5-9e67-bea27195236d" />

https://github.com/user-attachments/assets/28c71540-459c-4db6-ab2e-803fa709ba64


